### PR TITLE
Result object

### DIFF
--- a/Classes/LJSLiveDataResult.h
+++ b/Classes/LJSLiveDataResult.h
@@ -9,9 +9,20 @@
 #import <Foundation/Foundation.h>
 
 @class LJSStop;
+
+/**
+ *  A Live Data Result object represents the successful parsing of HTML by a Your Next Bus client. A client can finish successfully with a Stop (representing the departures for the next hour) and no messages. A client can also finish with no Stop (when there are no departure) but still generate an array of messages (representing meta information such as warnings). Finally a client can finish with both a Stop and an array of messages.
+ */
 @interface LJSLiveDataResult : NSObject
 
+/**
+ *  The Stop representing the successful parsing of live departure data from HTML. Or nil if the HTML did not contain any data.
+ */
 @property (nonatomic, strong, readonly) LJSStop *stop;
+
+/**
+ *  An array of messages representing meta information such as warnings. Or nil if the HTML did not contain any data.
+ */
 @property (nonatomic, copy, readonly) NSArray *messages;
 
 - (instancetype)initWithStop:(LJSStop *)stop messages:(NSArray *)messages;

--- a/Classes/LJSLiveDataResult.h
+++ b/Classes/LJSLiveDataResult.h
@@ -1,0 +1,19 @@
+//
+//  LJSLiveDataResult.h
+//  LJSYourNextBus
+//
+//  Created by Luke Stringer on 31/07/2015.
+//  Copyright (c) 2015 Luke Stringer. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class LJSStop;
+@interface LJSLiveDataResult : NSObject
+
+@property (nonatomic, strong, readonly) LJSStop *stop;
+@property (nonatomic, copy, readonly) NSArray *messages;
+
+- (instancetype)initWithStop:(LJSStop *)stop messages:(NSArray *)messages;
+
+@end

--- a/Classes/LJSLiveDataResult.h
+++ b/Classes/LJSLiveDataResult.h
@@ -16,6 +16,11 @@
 @interface LJSLiveDataResult : NSObject
 
 /**
+ *  NaPTAN code of the original request to get live data.
+ */
+@property (nonatomic, strong, readonly) NSString *NaPTANCode;
+
+/**
  *  The Stop representing the successful parsing of live departure data from HTML. Or nil if the HTML did not contain any data.
  */
 @property (nonatomic, strong, readonly) LJSStop *stop;
@@ -25,6 +30,6 @@
  */
 @property (nonatomic, copy, readonly) NSArray *messages;
 
-- (instancetype)initWithStop:(LJSStop *)stop messages:(NSArray *)messages;
+- (instancetype)initWithNaPTANCode:(NSString *)NaPTANCode stop:(LJSStop *)stop messages:(NSArray *)messages;
 
 @end

--- a/Classes/LJSLiveDataResult.m
+++ b/Classes/LJSLiveDataResult.m
@@ -1,0 +1,27 @@
+//
+//  LJSLiveDataResult.m
+//  LJSYourNextBus
+//
+//  Created by Luke Stringer on 31/07/2015.
+//  Copyright (c) 2015 Luke Stringer. All rights reserved.
+//
+
+#import "LJSLiveDataResult.h"
+
+@interface LJSLiveDataResult ()
+@property (nonatomic, strong, readwrite) LJSStop *stop;
+@property (nonatomic, copy, readwrite) NSArray *messages;
+@end
+
+@implementation LJSLiveDataResult
+
+- (instancetype)initWithStop:(LJSStop *)stop messages:(NSArray *)messages
+{
+	if (self = [super init]) {
+		self.stop = stop;
+		self.messages = messages;
+	}
+	return self;
+}
+
+@end

--- a/Classes/LJSLiveDataResult.m
+++ b/Classes/LJSLiveDataResult.m
@@ -9,15 +9,17 @@
 #import "LJSLiveDataResult.h"
 
 @interface LJSLiveDataResult ()
+@property (nonatomic, strong, readwrite) NSString *NaPTANCode;
 @property (nonatomic, strong, readwrite) LJSStop *stop;
 @property (nonatomic, copy, readwrite) NSArray *messages;
 @end
 
 @implementation LJSLiveDataResult
 
-- (instancetype)initWithStop:(LJSStop *)stop messages:(NSArray *)messages
+- (instancetype)initWithNaPTANCode:(NSString *)NaPTANCode stop:(LJSStop *)stop messages:(NSArray *)messages
 {
 	if (self = [super init]) {
+		self.NaPTANCode = NaPTANCode;
 		self.stop = stop;
 		self.messages = messages;
 	}

--- a/Classes/LJSStop.h
+++ b/Classes/LJSStop.h
@@ -16,7 +16,7 @@
 @end
 
 /**
- *  A Stop represents the results from parsing HTML and should be considered relevant for no longer than 60 seconds. It is the root of the live data hierarchy and has a list of Services each of which have a list of Departures for the next hour.
+ *  A Stop represents the successful parsing of live departure data from HTML. It is the root of the live data hierarchy and has a list of Services each of which have a list of Departures for the next hour. A Stop should only be considered relevant for no longer than 60 seconds.
  */
 @interface LJSStop : NSObject <NSCopying>
 

--- a/Classes/LJSYourNextBusClient.h
+++ b/Classes/LJSYourNextBusClient.h
@@ -27,17 +27,16 @@ typedef NS_ENUM(NSInteger, LJSYourNextBusError) {
 	LJSYourNextBusErrorDataUnavaiable
 };
 
-@class LJSYourNextBusClient, LJSStop;
+@class LJSYourNextBusClient, LJSStop, LJSLiveDataResult;
 @protocol LJSYourNextBusClientDelegate <NSObject>
 
 /**
- *  Delegate callback when the client has successfully obtained live data.
+ *   Delegate callback when the client has successfully obtained live data.
  *
- *  @param client   The Your Next Bus client that has obtained data.
- *  @param stop     A Stop object representing the live data.
- *  @param messages A list of messages for the stop live data containing meta information about the stop such as warnings or alerts. Or nil if their are no messages.
+ *  @param client The Your Next Bus client that has obtained data.
+ *  @param result The obtained live data - a Result object that contains an optional Stop object detailing the departure information, and an optional array of messages containing meta information about the Stop such as warnings or alerts.
  */
-- (void)client:(LJSYourNextBusClient *)client returnedStop:(LJSStop *)stop messages:(NSArray *)messages;
+- (void)client:(LJSYourNextBusClient *)client returnedLiveDataResult:(LJSLiveDataResult *)result;
 
 /**
  *  Delegate callback when the client has failed to obtained live data.

--- a/Classes/LJSYourNextBusClient.m
+++ b/Classes/LJSYourNextBusClient.m
@@ -10,6 +10,7 @@
 #import "LJSHTMLDownloader.h"
 #import "LJSScraper.h"
 #import "LJSStop.h"
+#import "LJSLiveDataResult.h"
 
 NSString * const LJSYourNextBusErrorDomain = @"com.yournextbus.domain";
 
@@ -99,15 +100,16 @@ NSString * const LJSYourNextBusErrorDomain = @"com.yournextbus.domain";
 }
 
 - (void)handleFinishWithStop:(LJSStop *)stop messages:(NSArray *)messages error:(NSError *)error {
-
+	LJSLiveDataResult *result = [[LJSLiveDataResult alloc] initWithStop:stop messages:messages];
+	
 	[[NSOperationQueue mainQueue] addOperationWithBlock:^{
 		self.gettingLiveData = NO;
 		
 		if (error && [self.clientDelegate respondsToSelector:@selector(client:failedWithError:NaPTANCode:)]) {
 			[self.clientDelegate client:self failedWithError:error NaPTANCode:self.NaPTANCode];
 		}
-		else if ([self.clientDelegate respondsToSelector:@selector(client:returnedStop:messages:)]) {
-			[self.clientDelegate client:self returnedStop:stop messages:messages];
+		else if ([self.clientDelegate respondsToSelector:@selector(client:returnedLiveDataResult:)]) {
+			[self.clientDelegate client:self returnedLiveDataResult:result];
 		}
 		
 	}];

--- a/Classes/LJSYourNextBusClient.m
+++ b/Classes/LJSYourNextBusClient.m
@@ -100,7 +100,7 @@ NSString * const LJSYourNextBusErrorDomain = @"com.yournextbus.domain";
 }
 
 - (void)handleFinishWithStop:(LJSStop *)stop messages:(NSArray *)messages error:(NSError *)error {
-	LJSLiveDataResult *result = [[LJSLiveDataResult alloc] initWithStop:stop messages:messages];
+	LJSLiveDataResult *result = [[LJSLiveDataResult alloc] initWithNaPTANCode:self.NaPTANCode stop:stop messages:messages];
 	
 	[[NSOperationQueue mainQueue] addOperationWithBlock:^{
 		self.gettingLiveData = NO;

--- a/Project/LJSYourNextBus.xcodeproj/project.pbxproj
+++ b/Project/LJSYourNextBus.xcodeproj/project.pbxproj
@@ -28,7 +28,8 @@
 		A34A1951189EB768002EEF2B /* LJSYourNextBusTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A34A1950189EB768002EEF2B /* LJSYourNextBusTests.m */; };
 		A34A1957189EBF86002EEF2B /* 37010071.html in Resources */ = {isa = PBXBuildFile; fileRef = A34A1956189EBF86002EEF2B /* 37010071.html */; };
 		A34B1C1918CE49F800184A12 /* 37010115.html in Resources */ = {isa = PBXBuildFile; fileRef = A34B1C1818CE49F800184A12 /* 37010115.html */; };
-		A35CF47C1B6C06BA006CDD11 /* LJSDelayedMockHTMLDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = A35CF47B1B6C06BA006CDD11 /* LJSDelayedMockHTMLDownloader.m */; };
+		A35CF4791B6BF926006CDD11 /* LJSLiveDataResult.m in Sources */ = {isa = PBXBuildFile; fileRef = A35CF4781B6BF926006CDD11 /* LJSLiveDataResult.m */; };
+		A35CF47F1B6C1046006CDD11 /* LJSDelayedMockHTMLDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = A35CF47E1B6C1046006CDD11 /* LJSDelayedMockHTMLDownloader.m */; };
 		A37DE9AE18E874A800795500 /* NSDate+LJSCountDownString.m in Sources */ = {isa = PBXBuildFile; fileRef = A37DE9AD18E874A800795500 /* NSDate+LJSCountDownString.m */; };
 		A388BE5C19686A0F00CF4DA3 /* invalid_2.html in Resources */ = {isa = PBXBuildFile; fileRef = A388BE5B19686A0F00CF4DA3 /* invalid_2.html */; };
 		A388CE5D18E0EE4900B28A6C /* LJSNSDateCountDownStringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A388CE5C18E0EE4900B28A6C /* LJSNSDateCountDownStringTests.m */; };
@@ -98,8 +99,10 @@
 		A34A1950189EB768002EEF2B /* LJSYourNextBusTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = LJSYourNextBusTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		A34A1956189EBF86002EEF2B /* 37010071.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; lineEnding = 2; path = 37010071.html; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.html; };
 		A34B1C1818CE49F800184A12 /* 37010115.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; lineEnding = 2; path = 37010115.html; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.html; };
-		A35CF47A1B6C06BA006CDD11 /* LJSDelayedMockHTMLDownloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LJSDelayedMockHTMLDownloader.h; sourceTree = "<group>"; };
-		A35CF47B1B6C06BA006CDD11 /* LJSDelayedMockHTMLDownloader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LJSDelayedMockHTMLDownloader.m; sourceTree = "<group>"; };
+		A35CF4771B6BF926006CDD11 /* LJSLiveDataResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LJSLiveDataResult.h; path = ../../Classes/LJSLiveDataResult.h; sourceTree = "<group>"; };
+		A35CF4781B6BF926006CDD11 /* LJSLiveDataResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LJSLiveDataResult.m; path = ../../Classes/LJSLiveDataResult.m; sourceTree = "<group>"; };
+		A35CF47D1B6C1046006CDD11 /* LJSDelayedMockHTMLDownloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LJSDelayedMockHTMLDownloader.h; sourceTree = "<group>"; };
+		A35CF47E1B6C1046006CDD11 /* LJSDelayedMockHTMLDownloader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LJSDelayedMockHTMLDownloader.m; sourceTree = "<group>"; };
 		A37DE9AC18E874A800795500 /* NSDate+LJSCountDownString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSDate+LJSCountDownString.h"; path = "../../Classes/NSDate+LJSCountDownString.h"; sourceTree = "<group>"; };
 		A37DE9AD18E874A800795500 /* NSDate+LJSCountDownString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSDate+LJSCountDownString.m"; path = "../../Classes/NSDate+LJSCountDownString.m"; sourceTree = "<group>"; };
 		A388BE5B19686A0F00CF4DA3 /* invalid_2.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = invalid_2.html; sourceTree = "<group>"; };
@@ -293,10 +296,10 @@
 		A37DE9A518E86A7B00795500 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				A35CF47D1B6C1046006CDD11 /* LJSDelayedMockHTMLDownloader.h */,
+				A35CF47E1B6C1046006CDD11 /* LJSDelayedMockHTMLDownloader.m */,
 				A3B37FBD18E4A16E00B6D445 /* LJSMockHTMLDownloader.h */,
 				A3B37FBE18E4A16E00B6D445 /* LJSMockHTMLDownloader.m */,
-				A35CF47A1B6C06BA006CDD11 /* LJSDelayedMockHTMLDownloader.h */,
-				A35CF47B1B6C06BA006CDD11 /* LJSDelayedMockHTMLDownloader.m */,
 			);
 			name = Mocks;
 			sourceTree = "<group>";
@@ -329,6 +332,8 @@
 				A3BD275C189EF72200540C5F /* LJSService.m */,
 				A3BD2753189EF72200540C5F /* LJSDeparture.h */,
 				A3BD2754189EF72200540C5F /* LJSDeparture.m */,
+				A35CF4771B6BF926006CDD11 /* LJSLiveDataResult.h */,
+				A35CF4781B6BF926006CDD11 /* LJSLiveDataResult.m */,
 			);
 			name = Public;
 			sourceTree = "<group>";
@@ -559,6 +564,7 @@
 				A3BD2761189EF72200540C5F /* LJSYourNextBusClient.m in Sources */,
 				A3D058B819BA3E8200084C12 /* LJSWestYorkshireClient.m in Sources */,
 				A3D5BEF918E0A3AE00622915 /* LJSDepatureCell.m in Sources */,
+				A35CF4791B6BF926006CDD11 /* LJSLiveDataResult.m in Sources */,
 				A3B02E2B1B6AA23A00D029F8 /* LJSDepartureBuilder.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -569,7 +575,7 @@
 			files = (
 				A337FDA718C3A1BE002FB29F /* LJSDepartureDateParserTests.m in Sources */,
 				A3B02E1C1B6A8BA000D029F8 /* LJSStopBuilderTests.m in Sources */,
-				A35CF47C1B6C06BA006CDD11 /* LJSDelayedMockHTMLDownloader.m in Sources */,
+				A35CF47F1B6C1046006CDD11 /* LJSDelayedMockHTMLDownloader.m in Sources */,
 				A337FDA918C3BD05002FB29F /* LJSServiceTests.m in Sources */,
 				A337FDAB18C3C7C1002FB29F /* LJSDepartureTests.m in Sources */,
 				A3B02E221B6A9C0A00D029F8 /* LJSServiceBuilderTests.m in Sources */,

--- a/Project/LJSYourNextBus/LJSLiveDataViewController.m
+++ b/Project/LJSYourNextBus/LJSLiveDataViewController.m
@@ -12,6 +12,7 @@
 #import "LJSService.h"
 #import "LJSDeparture.h"
 #import "LJSDepatureCell.h"
+#import "LJSLiveDataResult.h"
 
 @interface LJSLiveDataViewController () <LJSYourNextBusScrapeDelegate, LJSYourNextBusClientDelegate>
 @property (nonatomic, copy, readwrite) NSString *NaPTANCode;
@@ -90,11 +91,11 @@
 
 #pragma mark - LJSYourNextBusStopDelegate
 
-- (void)client:(LJSYourNextBusClient *)client returnedStop:(LJSStop *)stop messages:(NSArray *)messages {
+- (void)client:(LJSYourNextBusClient *)client returnedLiveDataResult:(LJSLiveDataResult *)result {
 	[self.refreshControl endRefreshing];
-	self.stop = stop;
+	self.stop = result.stop;
 	self.title = self.stop.title;
-	self.allDepartures = [stop sortedDepartures];
+	self.allDepartures = [self.stop sortedDepartures];
 	[self.tableView reloadSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:UITableViewRowAnimationAutomatic];
 }
 

--- a/Project/LJSYourNextBusTests/LJSYourNextBusTests.m
+++ b/Project/LJSYourNextBusTests/LJSYourNextBusTests.m
@@ -25,6 +25,7 @@
 #import "LJSStop.h"
 #import "LJSService.h"
 #import "LJSDeparture.h"
+#import "LJSLiveDataResult.h"
 
 @interface LJSYourNextBusClient (TestVisibility)
 @property (nonatomic, strong) LJSHTMLDownloader *htmlDownloader;
@@ -69,9 +70,9 @@
 }
 
 #pragma mark - LJSYourNextBusScrapeDelegate
-- (void)client:(LJSYourNextBusClient *)client returnedStop:(LJSStop *)stop messages:(NSArray *)messages {
-	self.returnedStop = stop;
-	self.messages = messages;
+- (void)client:(LJSYourNextBusClient *)client returnedLiveDataResult:(LJSLiveDataResult *)result {
+	self.returnedStop = result.stop;
+	self.messages = result.messages;
 	self.delegateCalledForReturnedStop = YES;
 }
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ client.clientDelegate = self;
 	NSLog(@"Failed to get live data for NaPTAN: %@ with error: %@", NaPTANCode, error);
 }
 
-- (void)client:(LJSYourNextBusClient *)client returnedStop:(LJSStop *)stop messages:(NSArray *)messages {
+- (void)client:(LJSYourNextBusClient *)client returnedLiveDataResult:(LJSLiveDataResult *)result {
+	LJSStop *stop = result.stop;
 	NSLog(@"Live Data for: %@ %@", stop.NaPTANCode, stop.title);
 	for (LJSDeparture *departure in [stop sortedDepartures]) {
 		NSLog(@"\t%@ at %@", departure.service.title, departure.countdownString);


### PR DESCRIPTION
A LJSLiveDataResult encapsulates all the live data the client can return:
A Stop object representing the successful parsing of departure data.
An array of messages represents the successful parsing of any messages in
the HTMl.

By wrapping the Stop and the messages up in a Result object it is clearer
that the client can finish successfully without a Stop (when there are no
departures for the next hour) but with still have some messages. Conversely
the client can finish successfully with a Stop and no messages. In both
of these successful scenarios you will be returned a Result object.
